### PR TITLE
Fix compile error in `optional.hpp`

### DIFF
--- a/include/mpark/patterns/optional.hpp
+++ b/include/mpark/patterns/optional.hpp
@@ -43,7 +43,7 @@ namespace mpark {
 
   }  // namespace patterns
 
-  constexpr patterns::None none;
+  constexpr patterns::None none{};
 
   template <typename Pattern>
   auto some(const Pattern &pattern) { return patterns::Some<Pattern>{pattern}; }


### PR DESCRIPTION
This fixes a compile error in optional.hpp.
Example:
```c++
#include <iostream>
#include <mpark/match.hpp>

int factorial(int n) {
  using namespace mpark;
  return match(n)(pattern(0) = [] { return 1; },
                  pattern(arg) = [](auto n) { return n * factorial(n - 1); });
}

int main() {
  std::cout << factorial(5) << std::endl;
}
```

Error:
```
In file included from test.cpp:4:
In file included from /usr/local/include/mpark/match.hpp:265:
/usr/local/include/mpark/patterns/optional.hpp:46:28: error: default initialization of an object of const type 'const patterns::None' without a user-provided default constructor
  constexpr patterns::None none;
                           ^
                               {}
1 error generated.
```